### PR TITLE
Ajout d'une page de visualisation des données avec Chart.js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,7 +25,7 @@ checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -30,9 +36,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8582122b8edba2af43eaf6b80dbfd33f421b5a0eb3a3113d21bc096ac5b44faf"
+checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -56,7 +62,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -116,18 +121,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
- "time",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -170,7 +174,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -187,7 +191,7 @@ checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -301,7 +305,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -342,7 +346,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -411,12 +415,6 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -528,9 +526,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -571,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "link-cplusplus"
@@ -634,14 +632,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mime"
@@ -663,7 +661,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -675,16 +673,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -737,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
@@ -758,7 +746,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -788,7 +776,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -805,18 +793,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -995,22 +983,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.154"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1097,6 +1085,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,17 +1108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -1165,7 +1153,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1207,25 +1195,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1339,12 +1308,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -1370,7 +1333,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -1404,7 +1367,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1481,7 +1444,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
 ]
 
 [[package]]
@@ -1490,13 +1453,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1506,10 +1484,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1518,10 +1508,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1530,16 +1532,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"

--- a/src/app/api/fetch_salaries.rs
+++ b/src/app/api/fetch_salaries.rs
@@ -50,7 +50,7 @@ pub async fn fetch_salaries(
 ) -> Result<Json<Vec<Response>>, Error> {
     let order = Order::from(params);
 
-    match use_cases::fetch_salaries(repo, order).await {
+    match use_cases::fetch_sorted_salaries(repo, order).await {
         Ok(salaries) => Ok(salaries
             .into_iter()
             .map(|salary| salary.into())

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -50,6 +50,7 @@ pub async fn serve(
         let router = Router::new()
             .route("/", get(www::index::get))
             .route("/sort", get(www::sort::get))
+            .route("/graphs/", get(www::graphs::get))
             .route("/notification", delete(www::notification::delete))
             .route("/api/salaries", get(api::fetch_salaries))
             .route("/api/companies", get(api::fetch_companies))

--- a/src/app/www/components/graph.rs
+++ b/src/app/www/components/graph.rs
@@ -1,0 +1,198 @@
+use maud::{html, Markup, Render};
+
+use crate::app::www::i18n::I18n;
+
+pub(crate) struct Dataset {
+    label: String,
+    data: Vec<(i32, i32, String)>,
+}
+
+impl Dataset {
+    pub fn new(label: &str, data: Vec<(i32, i32, String)>) -> Self {
+        Self {
+            label: String::from(label.replace("'", "\\'")),
+            data: data
+                .into_iter()
+                .map(|(a, b, s)| (a, b, s.replace("'", "\\'")))
+                .collect(),
+        }
+    }
+}
+
+pub(crate) struct Graph {
+    id: String,
+    kind: String,
+    datasets: Vec<Dataset>,
+    xlabel: String,
+    ylabel: String,
+    title: String,
+    subtitle: Option<String>,
+}
+
+impl Graph {
+    pub fn new(
+        id: &str,
+        kind: &str,
+        mut datasets: Vec<Dataset>,
+        xlabel: &str,
+        ylabel: &str,
+        title: &str,
+        subtitle: Option<&str>,
+    ) -> Self {
+        // Order datasets by decreasing size for nicer rendering.
+        datasets.sort_by_key(|ds| usize::MAX - ds.data.len());
+        Self {
+            id: String::from(id),
+            kind: String::from(kind),
+            datasets,
+            xlabel: xlabel.replace("'", "\\'"),
+            ylabel: ylabel.replace("'", "\\'"),
+            title: title.replace("'", "\\'"),
+            subtitle: subtitle.map(|s| s.replace("'", "\\'")),
+        }
+    }
+}
+
+impl Render for Graph {
+    fn render(&self) -> Markup {
+        html! {
+            canvas #(self.id) style="
+            padding: 20px; 
+            margin: auto;
+            display: block;
+            width: 95%;" {};
+            script {
+                "Chart.defaults.color = '#000';"
+                "Chart.defaults.font.size = 16;"
+                (format!("var ctx = document.getElementById('{}');", self.id))
+                "var data = {
+                    datasets: ["
+                    @for (i, ds) in self.datasets.iter().enumerate() {
+                        (format!("{{ label: '{}',", ds.label))
+                            "data: ["
+                            @for (x, y, s) in &ds.data {
+                                "{ x: " (x) ", y:" (y) ", data: '" (s) "', },"
+                            }
+                            "],"
+                            "
+                            backgroundColor: '" (get_color(i))"',
+                            borderColor: '#222'
+                        },"
+                    }
+                    "]
+                };"
+                {
+                    "var config = {
+                        type: '" (self.kind) "',
+                        data: data,
+                        options: {
+                            scales: {
+                                x: {
+                                    type: 'linear',
+                                    position: 'bottom',
+                                    title: {
+                                        display: true,
+                                        text: '" (self.xlabel) "'
+                                    }
+                                },
+                                y: {
+                                    title: {
+                                        display: true,
+                                        text: '" (self.ylabel) "'
+                                    }
+                                }
+                            },
+                            elements: {
+                                point: {
+                                    radius: 6,
+                                    hoverRadius: 8,
+                                }
+                            },
+                            plugins: {
+                                title: {
+                                    display: true,
+                                    text: '" (self.title) "'
+                                },"
+                                @if let Some(s) = &self.subtitle {
+                                    "subtitle: {
+                                        display: true,
+                                        text: '" (s) "'
+                                    },"    
+                                }
+                                "
+                                tooltip: {
+                                        callbacks: {
+                                        label: function(ctx) {
+                                            let label = '';
+                                            label += ctx.dataset.label;
+                                            label += ': ' + ctx.formattedValue;
+                                            label += ' -- ' + ctx.raw.data;
+                                            return label;
+                                        }
+                                    }
+                                },
+                                "
+                                "
+                            },
+                        }
+                    };
+                
+                    new Chart(ctx, config);"
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn view(min_size: usize, graphs: Vec<Graph>) -> Markup {
+    html! {
+        (make_filters(min_size))
+        script src="https://cdn.jsdelivr.net/npm/chart.js" {};
+        div {
+            @for g in graphs {
+                (g)
+            }
+        }
+    }
+}
+
+const COLORS: &[&str] = &[
+    "#1f78b4", "#b2df8a", "#33a02c", "#fb9a99", "#e31a1c", "#fdbf6f", "#ff7f00", "#cab2d6",
+    "#6a3d9a", "#ffff99", "#b15928", "#a6cee3",
+];
+fn get_color(i: usize) -> &'static str {
+    &COLORS[i % COLORS.len()]
+}
+
+fn make_filters(min_size: usize) -> Markup {
+    html! {
+        div style="
+            display: flex; justify-content: flex-end;
+            "
+        {
+            form style="
+                padding: 0 20px;
+                max-width: 500px;
+                height: fit-content;
+                border-bottom: 2px solid rgb(0, 0, 0);
+                border-left: 2px solid rgb(0, 0, 0);
+                border-radius: 4px;
+                "
+            {
+                h2 style="
+                    font-size: 16px;
+                    padding: 10px 32px;
+                    margin: 0;
+                    font-weight: bold;
+                    text-align: center;" 
+                    { (I18n::GraphFilters.translate()) }
+                label for="min_size" { (I18n::MinDataPointsFilter.translate()) ": " }
+                input #min_size type="number" min="0" name="min_size" value=(min_size)
+                    style="width: 100px; height: 1.5em;" { }
+                br;
+                input type="submit" value=(I18n::DoFilter.translate())
+                    style="float: right; margin: 5px 0 10px 0;" {}
+            }
+        }
+    }
+}

--- a/src/app/www/components/mod.rs
+++ b/src/app/www/components/mod.rs
@@ -1,6 +1,7 @@
 pub mod banner;
 pub mod dropdown;
 pub mod form;
+pub mod graph;
 pub mod hcaptcha;
 pub mod input;
 pub mod label;

--- a/src/app/www/controllers/graphs.rs
+++ b/src/app/www/controllers/graphs.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use maud::{html, Markup};
+use serde::Deserialize;
+
+use crate::{
+    app::www::{components::notification, pages, I18n},
+    domain::use_cases,
+    infra::SalaryRepository,
+};
+
+#[derive(Deserialize, Debug)]
+pub struct GraphQueryParams {
+    min_size: Option<usize>,
+}
+
+pub async fn get(
+    State(repo): State<Arc<dyn SalaryRepository>>,
+    Query(params): Query<GraphQueryParams>,
+) -> Markup {
+    let salaries = match use_cases::fetch_salaries(repo).await {
+        Ok(salaries) => salaries,
+        Err(use_cases::fetch_salaries::Error::Unknown(_)) => {
+            return html! { (notification::view(Some(I18n::SortError.translate()))) };
+        }
+    };
+
+    pages::graphs::view(salaries, params.min_size.unwrap_or(0), None)
+}

--- a/src/app/www/controllers/index.rs
+++ b/src/app/www/controllers/index.rs
@@ -36,7 +36,8 @@ pub async fn get(
 ) -> Markup {
     let order = Order::from(params.clone());
 
-    let salaries = match use_cases::fetch_salaries(salary_repo.clone(), order.clone()).await {
+    let salaries = match use_cases::fetch_sorted_salaries(salary_repo.clone(), order.clone()).await
+    {
         Ok(salaries) => salaries,
         Err(use_cases::fetch_salaries::Error::Unknown(_)) => {
             return pages::text_only::view(I18n::SalariesFetchingError.translate())

--- a/src/app/www/controllers/mod.rs
+++ b/src/app/www/controllers/mod.rs
@@ -1,3 +1,4 @@
+pub mod graphs;
 pub mod index;
 pub mod insert;
 pub mod maintenance;

--- a/src/app/www/controllers/sort.rs
+++ b/src/app/www/controllers/sort.rs
@@ -17,7 +17,7 @@ pub async fn get(
 ) -> Markup {
     let order = Order::from(params);
 
-    let salaries = match use_cases::fetch_salaries(repo, order.clone()).await {
+    let salaries = match use_cases::fetch_sorted_salaries(repo, order.clone()).await {
         Ok(salaries) => salaries,
         Err(use_cases::fetch_salaries::Error::Unknown(_)) => {
             return html! { (notification::view(Some(I18n::SortError.translate()))) }

--- a/src/app/www/fragments/graphs_list.rs
+++ b/src/app/www/fragments/graphs_list.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use maud::Markup;
+
+use crate::{
+    app::www::components::graph::{self, Dataset, Graph},
+    domain::models::Salary,
+};
+
+use super::super::i18n::I18n;
+
+pub fn view(salaries: Vec<Salary>, min_size: usize) -> Markup {
+    let mut by_city: HashMap<String, Vec<(i32, i32, String)>> = HashMap::new();
+    let mut by_company: HashMap<String, Vec<(i32, i32, String)>> = HashMap::new();
+    for s in salaries.clone() {
+        if let Ok(loc) = s.location.try_into() {
+            if let Ok(company_name) = s.company.try_into() {
+                if let Some(xp) = s.total_xp {
+                    let loc: String = loc;
+                    let company_name: String = company_name;
+                    let xp: i32 = xp.into();
+                    let comp: i32 = s.compensation.into();
+                    by_city.entry(loc.clone()).or_insert(vec![]).push((
+                        xp,
+                        comp,
+                        company_name.clone(),
+                    ));
+
+                    by_company
+                        .entry(company_name)
+                        .or_insert(vec![])
+                        .push((xp, comp, loc));
+                }
+            }
+        }
+    }
+
+    let scatter_exp_salary_city = Graph::new(
+        "exp_vs_salary_by_city",
+        "scatter",
+        by_city
+            .into_iter()
+            .filter(|(_, v)| v.len() >= min_size)
+            .map(|(city_name, values)| Dataset::new(&city_name, values))
+            .collect(),
+        &format!(
+            "{} ({})",
+            I18n::TotalXp.translate(),
+            I18n::InYears.translate(),
+        ),
+        I18n::Compensation.translate(),
+        I18n::CompensationVsTotalXpByCityTitle.translate(),
+        Some(I18n::CompensationVsTotalXpByCitySubTitle.translate()),
+    );
+
+    let scatter_exp_salary_company = Graph::new(
+        "exp_vs_salary_by_company",
+        "scatter",
+        by_company
+            .into_iter()
+            .filter(|(_, v)| v.len() >= min_size)
+            .map(|(cname, values)| Dataset::new(&cname, values))
+            .collect(),
+        &format!(
+            "{} ({})",
+            I18n::TotalXp.translate(),
+            I18n::InYears.translate(),
+        ),
+        I18n::Compensation.translate(),
+        I18n::CompensationVsTotalXpByCompanyTitle.translate(),
+        Some(I18n::CompensationVsTotalXpByCompanySubTitle.translate()),
+    );
+
+    graph::view(
+        min_size,
+        vec![scatter_exp_salary_city, scatter_exp_salary_company],
+    )
+}

--- a/src/app/www/fragments/mod.rs
+++ b/src/app/www/fragments/mod.rs
@@ -2,6 +2,7 @@ pub mod company_field;
 pub mod company_xp_field;
 pub mod compensation_field;
 pub mod email_field;
+pub mod graphs_list;
 pub mod level_field;
 pub mod location_field;
 pub mod salary_table;

--- a/src/app/www/i18n.rs
+++ b/src/app/www/i18n.rs
@@ -35,6 +35,13 @@ pub enum I18n {
     FormFetchingError,
     ValidationError,
     SortError,
+    CompensationVsTotalXpByCityTitle,
+    CompensationVsTotalXpByCitySubTitle,
+    CompensationVsTotalXpByCompanyTitle,
+    CompensationVsTotalXpByCompanySubTitle,
+    GraphFilters,
+    MinDataPointsFilter,
+    DoFilter,
 }
 
 impl I18n {
@@ -75,7 +82,14 @@ impl I18n {
             Self::SalariesFetchingError => "Les salaires n'ont pas pu être chargés",
             Self::FormFetchingError => "Le formulaire n'a pas pu être chargé",
             Self::ValidationError => "Une erreur inconnue est survenue lors de la validation du formulaire",
-            Self::SortError => "Une erreur inconnue est survenue lors du tri des salaires"
+            Self::SortError => "Une erreur inconnue est survenue lors du tri des salaires",
+            Self::CompensationVsTotalXpByCityTitle => "Compensation annuelle en fonction de l'expérience totale, par ville.",
+            Self::CompensationVsTotalXpByCitySubTitle => "Cliquez sur le nom d'une ville pour cacher/afficher les données correspondantes.",
+            Self::CompensationVsTotalXpByCompanyTitle => "Compensation annuelle en fonction de l'expérience totale, par entreprise.",
+            Self::CompensationVsTotalXpByCompanySubTitle => "Cliquez sur le nom d'une entreprise pour cacher/afficher les données correspondantes.",
+            Self::GraphFilters => "Filtres",
+            Self::MinDataPointsFilter => "Nombre minimum de données",
+            Self::DoFilter => "Filtrer",
         }
     }
 }

--- a/src/app/www/mod.rs
+++ b/src/app/www/mod.rs
@@ -5,6 +5,7 @@ mod i18n;
 mod models;
 mod pages;
 
+pub use controllers::graphs;
 pub use controllers::index;
 pub use controllers::insert;
 pub use controllers::maintenance;

--- a/src/app/www/pages/graphs.rs
+++ b/src/app/www/pages/graphs.rs
@@ -1,0 +1,9 @@
+use maud::Markup;
+
+use crate::domain::models::{Salary};
+
+use super::{super::fragments::graphs_list, template};
+
+pub fn view(salaries: Vec<Salary>, min_size: usize, notification: Option<&str>) -> Markup {
+    template::view(graphs_list::view(salaries, min_size), notification)
+}

--- a/src/app/www/pages/mod.rs
+++ b/src/app/www/pages/mod.rs
@@ -1,3 +1,4 @@
+pub mod graphs;
 pub mod index;
 pub mod insert;
 mod template;

--- a/src/app/www/pages/template.rs
+++ b/src/app/www/pages/template.rs
@@ -128,6 +128,7 @@ fn header() -> Markup {
                     {
                         (link::view("salaires.dev", "/"))
                         (link::view("Github", "https://github.com/alexislozano/salaires.dev"))
+                        (link::view("Graphes", "/graphs/?min_size=5"))
                     }
                 (link::view(I18n::IAddMySalary.translate(), "/insert"))
             }

--- a/src/domain/use_cases/mod.rs
+++ b/src/domain/use_cases/mod.rs
@@ -9,5 +9,6 @@ pub use confirm_token::confirm_token;
 pub use fetch_companies::fetch_companies;
 pub use fetch_locations::fetch_locations;
 pub use fetch_salaries::fetch_salaries;
+pub use fetch_salaries::fetch_sorted_salaries;
 pub use fetch_titles::fetch_titles;
 pub use insert_salary::insert_salary;

--- a/src/infra/salary_repository/in_memory.rs
+++ b/src/infra/salary_repository/in_memory.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 
 use super::{ConfirmError, FetchAllError, InsertError, SalaryRepository};
-use crate::domain::models::{salary::Key, Id, Order, Salary};
+use crate::domain::models::{Id, Salary};
 use async_trait::async_trait;
 
 pub struct InMemorySalaryRepository {
@@ -49,17 +49,15 @@ impl SalaryRepository for InMemorySalaryRepository {
         Ok(())
     }
 
-    async fn fetch_all(&self, order: Order<Key>) -> Result<Vec<Salary>, FetchAllError> {
+    async fn fetch_all(&self) -> Result<Vec<Salary>, FetchAllError> {
         if self.error {
             return Err(FetchAllError::Unknown("error flag is on"));
         }
 
-        let mut lock = match self.salaries.lock() {
+        let lock = match self.salaries.lock() {
             Ok(lock) => lock,
             _ => return Err(FetchAllError::Unknown("could not acquire lock")),
         };
-
-        lock.sort_by(|a, b| Salary::compare(&a, &b, &order));
 
         Ok(lock.to_vec())
     }

--- a/src/infra/salary_repository/mod.rs
+++ b/src/infra/salary_repository/mod.rs
@@ -19,6 +19,11 @@ pub enum InsertError {
 #[async_trait]
 pub trait SalaryRepository: Send + Sync {
     async fn confirm(&self, id: Id) -> Result<(), ConfirmError>;
-    async fn fetch_all(&self, order: Order<Key>) -> Result<Vec<Salary>, FetchAllError>;
+    async fn fetch_all(&self) -> Result<Vec<Salary>, FetchAllError>;
+    async fn fetch_all_sorted(&self, order: Order<Key>) -> Result<Vec<Salary>, FetchAllError> {
+        let mut salaries = self.fetch_all().await?;
+        salaries.sort_by(|a, b| Salary::compare(&a, &b, &order));
+        Ok(salaries)
+    }
     async fn insert(&self, salary: Salary) -> Result<(), InsertError>;
 }

--- a/src/infra/salary_repository/supabase.rs
+++ b/src/infra/salary_repository/supabase.rs
@@ -1,5 +1,5 @@
 use super::{ConfirmError, FetchAllError, InsertError, SalaryRepository};
-use crate::domain::models::{salary::Key, Id, Order, Salary, Status};
+use crate::domain::models::{Id, Salary, Status};
 use async_trait::async_trait;
 use axum::http::HeaderMap;
 use chrono::NaiveDate;
@@ -48,15 +48,16 @@ impl SalaryRepository for SupabaseSalaryRepository {
         }
     }
 
-    async fn fetch_all(&self, order: Order<Key>) -> Result<Vec<Salary>, FetchAllError> {
+    async fn fetch_all(&self) -> Result<Vec<Salary>, FetchAllError> {
         let client = reqwest::Client::new();
         let res = match client
             .get(format!(
-                "{}salaries?select=*&status=eq.{}&order={}.{}",
+                "{}salaries?select=*&status=eq.{}",
+                // "{}salaries?select=*&status=eq.{}&order={}.{}",
                 self.url,
                 String::from(Status::Published),
-                String::from(order.clone().key),
-                String::from(order.clone().direction)
+                // String::from(order.clone().key),
+                // String::from(order.clone().direction)
             ))
             .headers(self.headers())
             .send()
@@ -79,8 +80,6 @@ impl SalaryRepository for SupabaseSalaryRepository {
                 _ => return Err(FetchAllError::Unknown("could not convert to domain")),
             }
         }
-
-        salaries.sort_by(|a, b| Salary::compare(&a, &b, &order));
 
         Ok(salaries)
     }


### PR DESCRIPTION
Hello !

Avoir des données c'est bien, mais pouvoir visualiser les données, c'est encore mieux!

Cette PR ajoute une page "Graphes" au site, qui affiche une représentation graphique des données du site.
Les graphes sont réalisés avec la librairie [Chart.js V4](https://www.chartjs.org/).
Actuellement, il y a deux graphes, qui montrent la compensation totale en fonction de l'expérience totale, les données étant regroupées par villes dans le premier cas, et par entreprise dans le deuxième cas.  
La page inclut aussi un paramètre de filtrage (`min_size`, passé par l'URL), qui permet de ne pas afficher les villes/entreprises avec moins de `m̀in_size` points de données, et de rendre les graphes plus lisibles.

Je ne suis pas un expert en HTML/CSS, donc si quelqu'un peut faire une passe pour améliorer cet aspect là, je suis preneur.

**Autres changements**:  
J'ai refactoré le code qui `fetch` les salaires, comme je n'avais pas besoin des les recevoir triés. Il y a maintenant une fonction `fetch_sorted_salaries` qui fait ce que faisait la fonction `fetch_salaries` avant, et la fonction `fetch_salaries` renvoie les salaires, mais non triés. Une remarque, l'ancienne fonction fetch_salaries triait deux fois les données, une fois dans la requête, et une fois dans le code rust. La nouvelle `fetch_sorted_salaries` ne trie plus qu'une seule fois (dans le code rust), en se basant sur `fetch_salaries`.